### PR TITLE
Fix invalid next.config.js options detected issue

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,42 +1,31 @@
 const withImages = require('next-images');
-const withPlugins = require('next-compose-plugins');
 const withTM = require('next-transpile-modules')(['flotiq-components-react']);
 
-module.exports = withPlugins(
-    [
-        withTM,
-        [
-            withImages,
+const nextConfig = {
+    async rewrites() {
+        return [
             {
-                exclude: /\.svg$/,
+                source: '/',
+                destination: '/1',
             },
-        ],
-    ],
-
-    {
-        async rewrites() {
-            return [
-                {
-                    source: '/',
-                    destination: '/1',
-                },
-            ];
-        },
-        images: {
-            dangerouslyAllowSVG: true,
-            disableStaticImages: true,
-            domains: ['api.flotiq.com'],
-        },
-        webpack: (config, options) => {
-            if (!options.isServer) {
-                config.resolve.alias['@sentry/node'] = '@sentry/browser';
-            }
-            config.module.rules.push({
-                test: /\.svg$/,
-                issuer: { and: [/\.(js|ts)x?$/] },
-                use: ['@svgr/webpack'],
-            });
-            return config;
-        },
+        ];
     },
-);
+    images: {
+        dangerouslyAllowSVG: true,
+        disableStaticImages: true,
+        domains: ['api.flotiq.com'],
+    },
+    webpack: (config, options) => {
+        if (!options.isServer) {
+            config.resolve.alias['@sentry/node'] = '@sentry/browser';
+        }
+        config.module.rules.push({
+            test: /\.svg$/,
+            issuer: { and: [/\.(js|ts)x?$/] },
+            use: ['@svgr/webpack'],
+        });
+        return config;
+    },
+};
+
+module.exports = withTM(withImages(nextConfig));

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "highlight.js": "^11.9.0",
     "moment": "^2.30.1",
     "next": "12.3.4",
-    "next-compose-plugins": "^2.2.1",
     "next-images": "^1.8.5",
     "next-runtime-dotenv": "^1.5.1",
     "next-transpile-modules": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,11 +3991,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-compose-plugins@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz"
-  integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
-
 next-images@^1.8.5:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/next-images/-/next-images-1.8.5.tgz#2eb5535bb1d6c58a5c4e03bc3be6c72c8a053a45"


### PR DESCRIPTION
Error:
```
michal@DESKTOP-SKG77NC:~/projects/flotiq-nextjs-blog-1$ ^[[A
yarn dev
yarn run v1.22.21
$ next dev
warn  - Port 3000 is in use, trying 3001 instead.
ready - started server on 0.0.0.0:3001, url: http://localhost:3001
info  - Loaded env from /home/michal/projects/flotiq-nextjs-blog-1/.env.local
warn  - Invalid next.config.js options detected: 
  - The root value has an unexpected property, webpackDevMiddleware, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir,
 env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, 
poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  - The root value has an unexpected property, configOrigin, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, es
lint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredB
yHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  - The root value has an unexpected property, target, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint, 
excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  - The root value has an unexpected property, webpack5, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint
, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHea
der, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  - The root value has an unexpected property, exclude, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  - The value at .amp.canonicalBase must be 1 character or more but it was 0 characters.
  - The value at .assetPrefix must be 1 character or more but it was 0 characters.
  - The value at .experimental.outputFileTracingRoot must be 1 character or more but it was 0 characters.
  - The value at .i18n must be an object but it was null.

See more info here: https://nextjs.org/docs/messages/invalid-next-config
```

was caused by
[next-compose-plugins](https://github.com/cyrilwanner/next-compose-plugins)
https://github.com/cyrilwanner/next-compose-plugins/issues/59

Fix - remove composeplugins
