### PR TITLE
Format page router note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Next JS starter for blog with Flotiq source
 Kick off your project with this blog boilerplate. This starter ships with the main Next JS configuration files you might need to get up and running blazing fast with the blazing fast app generator for React.
 Check our live demo: [https://flotiq-nextjs-blog-1.netlify.app](https://flotiq-nextjs-blog-1.netlify.app) 
 
-On the main branch, you can see a project based on the Next.js app router. This setup leverages the latest routing capabilities provided by Next.js, offering improved performance and flexibility. On the `page-router` branch, there is a starter that uses an older version of routing, specifically the page router. This version might be more familiar to those who have worked with previous iterations of Next.js.
+> [!NOTE]
+> On the main branch, you can see a project based on the Next.js app router. This setup leverages the latest routing capabilities provided by Next.js, offering improved performance and flexibility. On the `page-router` branch, there is a starter that uses an older version of routing, specifically the page router. This version might be more familiar to those who have worked with previous iterations of Next.js.
 
 ## Quick start
 


### PR DESCRIPTION
It is very easy to overlook the fact that we are using the app router, but we also have a page router; it's worth pointing this out in the introduction.

Before
![image](https://github.com/user-attachments/assets/660601dc-4216-4ab0-9914-9e3e21ddee50)

After
![image](https://github.com/user-attachments/assets/47c5255e-fe8f-4b51-a170-62525956d120)
